### PR TITLE
Fixed issue with damage reduction imporoperly displaying in the Mechbay

### DIFF
--- a/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
+++ b/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
@@ -13,7 +13,6 @@ internal class DurabilityStat : IStatHandler
         {
             var value = mechDef.MechDefAssignedArmor;
             value *= ArmorMultiplier(mechDef);
-            //value *= DamageReductionMultiplierAll(mechDef);
             tooltipData.dataList.Add("<u>" + Strings.T("Armor") + "</u>", $"{value}");
         }
 

--- a/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
+++ b/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
@@ -18,8 +18,7 @@ internal class DurabilityStat : IStatHandler
 
         {
             var reduction = 1 - DamageReductionMultiplierAll(mechDef);
-            var percent = (int)(reduction * 100);
-            tooltipData.dataList.Add("<u>" + Strings.T("Damage Reduction") + "</u>", Strings.T($"{value * 100} %"));
+            tooltipData.dataList.Add("<u>" + Strings.T("Damage Reduction") + "</u>", Strings.T("{0:P0}", reduction));
 /*
 <float>("DamageReductionMultiplierAll", 1f);
 <float>("DamageReductionMultiplierMelee", 1f);

--- a/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
+++ b/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
@@ -17,7 +17,8 @@ internal class DurabilityStat : IStatHandler
         }
 
         {
-            var value = 1 - DamageReductionMultiplierAll(mechDef);
+            var reduction = 1 - DamageReductionMultiplierAll(mechDef);
+            var percent = (int)(reduction * 100);
             tooltipData.dataList.Add("<u>" + Strings.T("Damage Reduction") + "</u>", Strings.T($"{value * 100} %"));
 /*
 <float>("DamageReductionMultiplierAll", 1f);

--- a/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
+++ b/source/Features/OverrideStatTooltips/Stats/DurabilityStat.cs
@@ -1,4 +1,4 @@
-using BattleTech;
+﻿using BattleTech;
 using Localize;
 using MechEngineer.Features.ArmorStructureChanges;
 using MechEngineer.Features.OverrideStatTooltips.Helper;
@@ -13,13 +13,13 @@ internal class DurabilityStat : IStatHandler
         {
             var value = mechDef.MechDefAssignedArmor;
             value *= ArmorMultiplier(mechDef);
-            value *= DamageReductionMultiplierAll(mechDef);
+            //value *= DamageReductionMultiplierAll(mechDef);
             tooltipData.dataList.Add("<u>" + Strings.T("Armor") + "</u>", $"{value}");
         }
 
         {
-            var value = DamageReductionMultiplierAll(mechDef);
-            tooltipData.dataList.Add("<u>" + Strings.T("Damage Reduction") + "</u>", Strings.T("{0} %", value));
+            var value = 1 - DamageReductionMultiplierAll(mechDef);
+            tooltipData.dataList.Add("<u>" + Strings.T("Damage Reduction") + "</u>", Strings.T($"{value * 100} %"));
 /*
 <float>("DamageReductionMultiplierAll", 1f);
 <float>("DamageReductionMultiplierMelee", 1f);
@@ -69,7 +69,7 @@ internal class DurabilityStat : IStatHandler
     {
         var armor = mechDef.MechDefAssignedArmor;
         armor *= ArmorMultiplier(mechDef);
-        armor *= DamageReductionMultiplierAll(mechDef);
+        armor /= DamageReductionMultiplierAll(mechDef);
 
         var stats = UnityGameInstance.BattleTechGame.MechStatisticsConstants;
         return MechStatUtils.NormalizeToFraction(armor, 0, stats.MaxArmorFactor);


### PR DESCRIPTION
The durability stat was incorrectly handling damage reduction resulting in it decreasing both the displayed amount of armor and the durability value in the tooltip.

Additionally damage reduction was not being displayed at all.

These changes now allow damage reduction effects on the mech to properly increase the displayed durability, and displays the damage reduction % as part of the durability breakdown. Damage reduction no longer modifies the displayed armor value.